### PR TITLE
Fix #42 - issue with mixed single+dual guides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pycyto"
-version = "0.1.14"
+version = "0.1.15"
 description = "Python utilities used by cyto"
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/src/pycyto/aggregate.py
+++ b/src/pycyto/aggregate.py
@@ -288,9 +288,11 @@ def _load_assignments_for_experiment_sample(
             f"{crispr_bc}.assignments.tsv",
         )
         if os.path.exists(expected_crispr_assignments_path):
+            multi_guide_cols = ["guide_ids_original", "umis", "fdr", "log_odds"]
             bc_assignments = pl.read_csv(
                 expected_crispr_assignments_path,
                 separator="\t",
+                schema_overrides={c: pl.String for c in multi_guide_cols},
             ).with_columns(
                 pl.lit(sample).cast(pl.Categorical).alias("sample"),
                 pl.lit(experiment).cast(pl.Categorical).alias("experiment"),


### PR DESCRIPTION
Addresses issue #42 by force specifying that ["guide_ids_original", "umis", "fdr", "log_odds"] are strings, eliminating possibility of erroneously calling them as ints in event of mixed single and dual guides.