### PR TITLE
fix: include experiment in match_barcode and obs.index (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,12 @@ experiment | sample | mode | bc_component | bc_idx | features | probe_set | feat
 1. Detect barcode format (Flex-V1 vs Flex-V2) from GEX data
 2. **For Flex-V1**:
    - Detect if CRISPR uses CR prefixes by checking assignment data
-   - If CR detected: cell barcodes like `ACGTACGT-CR001-1` are converted to `ACGTACGT-BC001-1`
+   - If CR detected: cell barcodes like `ACGTACGT-CR001-1-experiment_name` are converted to `ACGTACGT-BC001-1-experiment_name`
    - If BC detected: no conversion needed, barcodes already match
 3. **For Flex-V2**:
    - No conversion needed - single naming scheme per barcode set
    - Both GEX and CRISPR use the same barcode identifiers (e.g., `A-A01`)
-4. Matching is always done on `cell_barcode + flex_barcode + lane_id`
+4. Matching is always done on `cell_barcode + flex_barcode + lane_id + experiment`
 
 See `_process_gex_crispr_set()` around line 140-160 for the detection and conversion logic.
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The aggregated GEX h5ad includes:
 
 When pairing GEX and CRISPR data:
 - CRISPR barcodes (CR) are automatically converted to match GEX format (BC) for cell matching
-- Cells are matched on: `cell_barcode + flex_barcode + lane_id`
+- Cells are matched on: `cell_barcode + flex_barcode + lane_id + experiment`
 - Only cells present in filtered GEX data are retained in CRISPR output
 
 ### Cyto Output Directory Structure

--- a/src/pycyto/aggregate.py
+++ b/src/pycyto/aggregate.py
@@ -83,10 +83,10 @@ def _filter_crispr_adata_to_gex_barcodes(
     Creates a dummy column on each that captures all unique information.
 
     # already annotated
-    index: (cell_barcode + flex_barcode + lane_id)
+    index: (cell_barcode + flex_barcode + lane_id + experiment)
 
     # to create
-    dummy = index + sample + experiment
+    dummy = index + sample + experiment  (sample appended defensively; experiment is already in index post-fix)
     """
     gex_adata.obs["dummy"] = (
         gex_adata.obs.index
@@ -157,12 +157,26 @@ def _process_gex_crispr_set(
             f"[{sample}] - Detected Flex-V1 CR barcodes, converting to BC format for matching"
         )
         assignments = assignments.with_columns(
-            match_barcode=pl.col("cell") + "-" + pl.col("lane_id").cast(pl.String)
-        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC"))
+            match_barcode=(
+                pl.col("cell")
+                + "-"
+                + pl.col("lane_id").cast(pl.String)
+                + "-"
+                + pl.col("experiment").cast(pl.String)
+            )
+        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC", n=1))
         reads_df = reads_df.with_columns(
-            match_barcode=pl.col("cell_id") + "-" + pl.col("lane_id").cast(pl.String)
-        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC"))
-        crispr_adata.obs.index = crispr_adata.obs.index.str.replace("CR", "BC")
+            match_barcode=(
+                pl.col("cell_id")
+                + "-"
+                + pl.col("lane_id").cast(pl.String)
+                + "-"
+                + pl.col("experiment").cast(pl.String)
+            )
+        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC", n=1))
+        crispr_adata.obs.index = crispr_adata.obs.index.str.replace(
+            r"^([ACGTN]+)-CR(\d+)-", r"\1-BC\2-", regex=True
+        )
     else:
         if is_flex_v2:
             logger.debug(
@@ -173,10 +187,22 @@ def _process_gex_crispr_set(
                 f"[{sample}] - Using standard Flex-V1 barcode format for matching"
             )
         assignments = assignments.with_columns(
-            match_barcode=pl.col("cell") + "-" + pl.col("lane_id").cast(pl.String)
+            match_barcode=(
+                pl.col("cell")
+                + "-"
+                + pl.col("lane_id").cast(pl.String)
+                + "-"
+                + pl.col("experiment").cast(pl.String)
+            )
         )
         reads_df = reads_df.with_columns(
-            match_barcode=pl.col("cell_id") + "-" + pl.col("lane_id").cast(pl.String)
+            match_barcode=(
+                pl.col("cell_id")
+                + "-"
+                + pl.col("lane_id").cast(pl.String)
+                + "-"
+                + pl.col("experiment").cast(pl.String)
+            )
         )
 
     logger.info(f"[{sample}] - Writing assignments data...")
@@ -324,7 +350,12 @@ def _load_gex_anndata_for_experiment_sample(
             bc_adata.obs["experiment"] = experiment
             bc_adata.obs["lane_id"] = lane_id
             bc_adata.obs["bc_idx"] = gex_bc
-            bc_adata.obs.index += "-" + bc_adata.obs["lane_id"].astype(str)  # type: ignore
+            bc_adata.obs.index += (  # type: ignore
+                "-"
+                + bc_adata.obs["lane_id"].astype(str)
+                + "-"
+                + bc_adata.obs["experiment"].astype(str)
+            )
             gex_adata_list.append(bc_adata)
         else:
             logger.warning(
@@ -352,7 +383,12 @@ def _load_crispr_anndata_for_experiment_sample(
             bc_adata.obs["experiment"] = experiment
             bc_adata.obs["lane_id"] = lane_id
             bc_adata.obs["bc_idx"] = crispr_bc
-            bc_adata.obs.index += "-" + bc_adata.obs["lane_id"].astype(str)  # type: ignore
+            bc_adata.obs.index += (  # type: ignore
+                "-"
+                + bc_adata.obs["lane_id"].astype(str)
+                + "-"
+                + bc_adata.obs["experiment"].astype(str)
+            )
             crispr_adata_list.append(bc_adata)
         else:
             logger.warning(

--- a/src/pycyto/aggregate.py
+++ b/src/pycyto/aggregate.py
@@ -164,7 +164,9 @@ def _process_gex_crispr_set(
                 + "-"
                 + pl.col("experiment").cast(pl.String)
             )
-        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC", n=1))
+        ).with_columns(
+            pl.col("match_barcode").str.replace(r"^([ACGTN]+)-CR(\d+)-", r"$1-BC$2-")
+        )
         reads_df = reads_df.with_columns(
             match_barcode=(
                 pl.col("cell_id")
@@ -173,7 +175,9 @@ def _process_gex_crispr_set(
                 + "-"
                 + pl.col("experiment").cast(pl.String)
             )
-        ).with_columns(pl.col("match_barcode").str.replace("CR", "BC", n=1))
+        ).with_columns(
+            pl.col("match_barcode").str.replace(r"^([ACGTN]+)-CR(\d+)-", r"$1-BC$2-")
+        )
         crispr_adata.obs.index = crispr_adata.obs.index.str.replace(
             r"^([ACGTN]+)-CR(\d+)-", r"\1-BC\2-", regex=True
         )

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,21 @@ Tests the configuration parsing system, especially the lane removal refactoring 
 - `TestModeAndFeatureParsing`: Mode and feature string parsing
 - `TestConfigParsingIntegration`: End-to-end config parsing scenarios
 
+### `test_aggregate.py`
+Tests the multi-modal aggregation pipeline in `aggregate.py`, including the cross-experiment same-sample disambiguation introduced for issue #46.
+
+**Key Features Tested:**
+- **Cross-experiment same-sample**: Verifies that the same `sample` under multiple `experiment` values no longer collides during the `match_barcode` merge.
+- **CR→BC conversion**: Confirms the pandas anchored regex correctly rewrites the flex-barcode prefix without corrupting experiment names that happen to contain "CR".
+- **Single-modal universality**: The experiment suffix lands in `obs.index` for `gex`-only and `crispr`-only outputs too, preventing silent `obs_names_make_unique` deduplication.
+
+**Test Classes:**
+- `TestMultiExperimentSameSample`: Three tests covering crash absence, cell count, and per-experiment attribution (gex+crispr mode).
+- `TestSingleExperimentRegression`: Asserts the single-experiment path still produces correct annotations and obs.index format.
+- `TestGEXOnlyMultiExperiment`: Locks in the universal-loader-fix invariant for single-modal GEX outputs.
+- `TestCRISPROnlyMultiExperiment`: Symmetric coverage for the CRISPR-only single-modal path.
+- `TestCREdgeCases`: Positive CR→BC conversion, experiment-name-contains-CR safety, BC-prefix CRISPR pathway.
+
 ## Running Tests
 
 ### Run All Tests

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,569 @@
+"""Tests for the aggregate module.
+
+Covers the cross-experiment same-sample fix for issue #46 plus regression
+coverage of the existing single-experiment paths and CR/BC edge cases.
+
+The fixtures build minimal cyto-output trees from scratch (no shared
+infrastructure exists). Each test goes through `parse_config` -> `process_sample`
+so that the directory-discovery and merge paths exercised mirror production.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import polars as pl
+import scipy.sparse as sp
+
+# Add src to path for imports (mirror the pattern used by other tests).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from pycyto.aggregate import process_sample
+from pycyto.config import parse_config
+
+
+def _write_mock_h5ad(path: Path, cell_sequences: list[str], flex_bc: str) -> None:
+    """Write a minimal h5ad whose obs.index matches cyto's `{seq}-{flex_bc}` format."""
+    obs_index = pd.Index([f"{seq}-{flex_bc}" for seq in cell_sequences])
+    adata = ad.AnnData(
+        X=sp.csr_matrix(np.zeros((len(cell_sequences), 1), dtype=np.float32)),
+        obs=pd.DataFrame(index=obs_index),
+        var=pd.DataFrame(index=pd.Index(["gene_1"])),
+    )
+    adata.write_h5ad(str(path))  # ty: ignore[invalid-argument-type]
+
+
+def _write_mock_reads(
+    path: Path,
+    cell_sequences: list[str],
+    n_reads: int,
+    n_umis: int,
+) -> None:
+    """Write a mock reads TSV (zstd compressed).
+
+    The `barcode` column is the raw cell sequence only; the loader appends the
+    `bc_idx` (flex barcode) downstream to construct `cell_id`.
+    """
+    pl.DataFrame(
+        {
+            "barcode": cell_sequences,
+            "n_reads": [n_reads] * len(cell_sequences),
+            "n_umis": [n_umis] * len(cell_sequences),
+        }
+    ).write_csv(path, separator="\t", compression="zstd", include_header=True)
+
+
+def _write_mock_assignments(
+    path: Path,
+    cell_sequences: list[str],
+    flex_bc: str,
+    assignment: str = "guide_1",
+) -> None:
+    """Write a mock assignments TSV.
+
+    The `cell` column carries the flex-barcode suffix (matches what cyto emits
+    and what `_process_gex_crispr_set` reads via `pl.col("cell").str.contains("CR")`).
+    """
+    cells = [f"{seq}-{flex_bc}" for seq in cell_sequences]
+    pl.DataFrame(
+        {
+            "cell": cells,
+            "assignment": [assignment] * len(cells),
+            "umis": [5] * len(cells),
+            "moi": [1] * len(cells),
+        }
+    ).write_csv(path, separator="\t", include_header=True)
+
+
+def _write_probe_stub(path: Path) -> None:
+    path.write_text("gene\tsequence\ngene_1\tATCG\n")
+
+
+def _build_cyto_dir(
+    root: Path,
+    experiment: str,
+    mode: str,
+    lane: int,
+    bc: str,
+    cell_sequences: list[str],
+    n_reads: int,
+    n_umis: int,
+    assignment: str = "guide_1",
+) -> Path:
+    """Build one cyto output directory for either GEX or CRISPR mode.
+
+    Always creates `counts/` and `stats/reads/`. Only creates `assignments/`
+    for the CRISPR mode.
+    """
+    mode_upper = mode.upper()
+    dir_path = root / f"{experiment}_{mode_upper}_Lane{lane}"
+    (dir_path / "counts").mkdir(parents=True, exist_ok=True)
+    (dir_path / "stats" / "reads").mkdir(parents=True, exist_ok=True)
+
+    suffix = ".filt.h5ad" if mode == "gex" else ".h5ad"
+    _write_mock_h5ad(dir_path / "counts" / f"{bc}{suffix}", cell_sequences, bc)
+    _write_mock_reads(
+        dir_path / "stats" / "reads" / f"{bc}.reads.tsv.zst",
+        cell_sequences,
+        n_reads,
+        n_umis,
+    )
+
+    if mode == "crispr":
+        (dir_path / "assignments").mkdir(parents=True, exist_ok=True)
+        _write_mock_assignments(
+            dir_path / "assignments" / f"{bc}.assignments.tsv",
+            cell_sequences,
+            bc,
+            assignment,
+        )
+
+    return dir_path
+
+
+def _write_and_parse_config(
+    tmp_path: Path,
+    libraries: dict[str, str],
+    samples: list[dict],
+) -> pl.DataFrame:
+    """Write a config JSON to tmp_path, materialize probe stubs, parse.
+
+    `libraries` values must be ABSOLUTE paths so that `_pull_feature_path`'s
+    `os.path.exists` check resolves regardless of test CWD.
+    """
+    for lib_path in libraries.values():
+        _write_probe_stub(Path(lib_path))
+
+    config_path = tmp_path / "config.json"
+    with open(config_path, "w") as f:
+        json.dump({"libraries": libraries, "samples": samples}, f)
+
+    return parse_config(str(config_path))
+
+
+# 16-character cell sequences. The first three overlap across experiments to
+# create the (cell_barcode, flex_barcode, lane_id) collision exercised by #46.
+_OVERLAP_SEQS = [
+    "AAAACCCCGGGGTTTT",
+    "ACGTACGTACGTACGT",
+    "TTTTGGGGCCCCAAAA",
+]
+_EXP_A_ONLY = ["AAAATTTTGGGGCCCC", "CCCCAAAATTTTGGGG"]
+_EXP_B_ONLY = ["GGGGCCCCAAAATTTT", "TTTTAAAACCCCGGGG"]
+
+
+class TestMultiExperimentSameSample:
+    """Reproduces issue #46: same `sample` under two experiments with overlapping cell barcodes."""
+
+    def _make_two_experiment_fixture(
+        self,
+        tmp_path: Path,
+        n_umis_a: int = 26,
+        n_umis_b: int = 3,
+    ) -> tuple[Path, Path, pl.DataFrame]:
+        """Build two cyto trees (exp_A and exp_B) sharing sample 'sample01' with BC001+CR001 pairing."""
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs_a = _OVERLAP_SEQS + _EXP_A_ONLY
+        seqs_b = _OVERLAP_SEQS + _EXP_B_ONLY
+
+        _build_cyto_dir(cyto_outdir, "exp_A", "gex", 1, "BC001", seqs_a, 100, n_umis_a)
+        _build_cyto_dir(cyto_outdir, "exp_A", "crispr", 1, "CR001", seqs_a, 50, 7)
+        _build_cyto_dir(cyto_outdir, "exp_B", "gex", 1, "BC001", seqs_b, 100, n_umis_b)
+        _build_cyto_dir(cyto_outdir, "exp_B", "crispr", 1, "CR001", seqs_b, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "exp_A",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+CR001",
+            },
+            {
+                "experiment": "exp_B",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+CR001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        return cyto_outdir, agg_outdir, config
+
+    def test_gex_crispr_two_experiments_does_not_crash(self, tmp_path):
+        """Reproduces issue #46. Fails on pre-fix code with ValueError from aggregate.py:236."""
+        cyto_outdir, agg_outdir, config = self._make_two_experiment_fixture(tmp_path)
+
+        # Must not raise ValueError: shape is inconsistent with obs
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        sample_dir = agg_outdir / "sample01"
+        assert (sample_dir / "sample01_gex.h5ad").exists()
+        assert (sample_dir / "sample01_crispr.h5ad").exists()
+        assert (sample_dir / "sample01_assignments.parquet").exists()
+        assert (sample_dir / "sample01_reads.parquet").exists()
+
+    def test_gex_crispr_two_experiments_correct_cell_count(self, tmp_path):
+        """5 cells per experiment with 3 overlapping sequences -> 10 distinct (seq, experiment) rows post-fix."""
+        cyto_outdir, agg_outdir, config = self._make_two_experiment_fixture(tmp_path)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        assert gex.shape[0] == 10
+        assert gex.obs["experiment"].value_counts().to_dict() == {
+            "exp_A": 5,
+            "exp_B": 5,
+        }
+        assert gex.obs.index.is_unique
+
+        # GEX output is always BC-prefixed (CR appears nowhere in GEX output).
+        pattern = re.compile(r"^[ACGTN]+-BC\d{3}-\d+-(exp_A|exp_B)$")
+        for idx in gex.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"obs.index entry {idx!r} does not match expected format"
+            )
+
+    def test_gex_crispr_two_experiments_correct_attribution(self, tmp_path):
+        """Distinct n_umis per experiment must attribute to the correct rows after the merge."""
+        cyto_outdir, agg_outdir, config = self._make_two_experiment_fixture(
+            tmp_path, n_umis_a=26, n_umis_b=3
+        )
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        exp_a_rows = gex.obs[gex.obs["experiment"] == "exp_A"]
+        exp_b_rows = gex.obs[gex.obs["experiment"] == "exp_B"]
+
+        assert (exp_a_rows["n_umis_gex"] == 26).all()
+        assert (exp_b_rows["n_umis_gex"] == 3).all()
+        assert (exp_a_rows["n_reads_gex"] == 100).all()
+        assert (exp_b_rows["n_reads_gex"] == 100).all()
+        assert (exp_a_rows["assignment"] == "guide_1").all()
+        assert (exp_b_rows["assignment"] == "guide_1").all()
+
+        # match_barcode column in both parquets carries experiment and has been CR->BC converted.
+        assignments = pl.read_parquet(
+            agg_outdir / "sample01" / "sample01_assignments.parquet"
+        )
+        reads = pl.read_parquet(agg_outdir / "sample01" / "sample01_reads.parquet")
+        mb_pattern = re.compile(r"^[ACGTN]+-BC\d{3}-\d+-(exp_A|exp_B)$")
+        for mb in assignments["match_barcode"].to_list():
+            assert mb_pattern.match(mb) is not None, (
+                f"assignments match_barcode {mb!r} unexpected"
+            )
+        for mb in reads["match_barcode"].to_list():
+            assert mb_pattern.match(mb) is not None, (
+                f"reads match_barcode {mb!r} unexpected"
+            )
+
+        # Reads parquet rows are correctly attributed per (mode, experiment) on the reads side.
+        gex_a_reads = reads.filter(
+            (pl.col("mode") == "gex") & (pl.col("experiment") == "exp_A")
+        )
+        gex_b_reads = reads.filter(
+            (pl.col("mode") == "gex") & (pl.col("experiment") == "exp_B")
+        )
+        assert gex_a_reads["n_umis"].to_list() == [26] * 5
+        assert gex_b_reads["n_umis"].to_list() == [3] * 5
+        assert gex_a_reads["n_reads"].to_list() == [100] * 5
+        assert gex_b_reads["n_reads"].to_list() == [100] * 5
+
+
+class TestSingleExperimentRegression:
+    """Regression coverage: the existing single-experiment path still works end-to-end."""
+
+    def test_single_experiment_single_barcode_gex_crispr(self, tmp_path):
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT", "TTTTGGGGCCCCAAAA"]
+        _build_cyto_dir(cyto_outdir, "exp_only", "gex", 1, "BC001", seqs, 100, 26)
+        _build_cyto_dir(cyto_outdir, "exp_only", "crispr", 1, "CR001", seqs, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "exp_only",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+CR001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        assert gex.shape[0] == 3
+        assert (gex.obs["n_reads_gex"] == 100).all()
+        assert (gex.obs["n_umis_gex"] == 26).all()
+        assert (gex.obs["assignment"] == "guide_1").all()
+
+        # End-to-end format lock-in.
+        pattern = re.compile(r"^[ACGTN]+-BC001-1-exp_only$")
+        for idx in gex.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"obs.index entry {idx!r} does not match expected format"
+            )
+
+
+class TestGEXOnlyMultiExperiment:
+    """The experiment suffix lands in obs.index for gex-only outputs too."""
+
+    def test_gex_only_two_experiments_unique_obs_index(self, tmp_path):
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        # 3 cells per experiment, 2 overlapping sequences across experiments.
+        seqs_a = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT", "AAAATTTTGGGGCCCC"]
+        seqs_b = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT", "GGGGCCCCAAAATTTT"]
+
+        _build_cyto_dir(cyto_outdir, "exp_A", "gex", 1, "BC001", seqs_a, 100, 26)
+        _build_cyto_dir(cyto_outdir, "exp_B", "gex", 1, "BC001", seqs_b, 100, 3)
+
+        libraries = {"GEX": str(tmp_path / "gex_probes.tsv")}
+        samples = [
+            {
+                "experiment": "exp_A",
+                "sample": "sample01",
+                "mode": "gex",
+                "features": "GEX",
+                "barcodes": "BC001",
+            },
+            {
+                "experiment": "exp_B",
+                "sample": "sample01",
+                "mode": "gex",
+                "features": "GEX",
+                "barcodes": "BC001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        # Pre-fix: obs_names_make_unique() silently renames the 2 collisions ->
+        # shape would still be 6, but indices would have synthetic "-1" suffixes.
+        # Post-fix: experiment suffix disambiguates -> all 6 indices unique and
+        # the experiment column is preserved.
+        assert gex.shape[0] == 6
+        assert gex.obs.index.is_unique
+        for idx in gex.obs.index:
+            assert idx.endswith("-exp_A") or idx.endswith("-exp_B"), (
+                f"obs.index entry {idx!r} missing experiment suffix"
+            )
+        assert gex.obs["experiment"].value_counts().to_dict() == {
+            "exp_A": 3,
+            "exp_B": 3,
+        }
+
+
+class TestCRISPROnlyMultiExperiment:
+    """Symmetric to TestGEXOnlyMultiExperiment for the CRISPR-only single-modal path.
+
+    Note: CRISPR-only never enters `_process_gex_crispr_set`, so the CR->BC
+    conversion at line 165 does NOT run for this path. obs.index retains the
+    raw `CR` prefix from the input file.
+    """
+
+    def test_crispr_only_two_experiments_unique_obs_index(self, tmp_path):
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs_a = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT", "AAAATTTTGGGGCCCC"]
+        seqs_b = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT", "GGGGCCCCAAAATTTT"]
+
+        _build_cyto_dir(cyto_outdir, "exp_A", "crispr", 1, "CR001", seqs_a, 50, 7)
+        _build_cyto_dir(cyto_outdir, "exp_B", "crispr", 1, "CR001", seqs_b, 50, 7)
+
+        libraries = {"GUIDES": str(tmp_path / "guides.tsv")}
+        samples = [
+            {
+                "experiment": "exp_A",
+                "sample": "sample01",
+                "mode": "crispr",
+                "features": "GUIDES",
+                "barcodes": "CR001",
+            },
+            {
+                "experiment": "exp_B",
+                "sample": "sample01",
+                "mode": "crispr",
+                "features": "GUIDES",
+                "barcodes": "CR001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        crispr = ad.read_h5ad(agg_outdir / "sample01" / "sample01_crispr.h5ad")
+        assert crispr.shape[0] == 6
+        assert crispr.obs.index.is_unique
+        # CRISPR-only path: raw CR prefix is retained.
+        pattern = re.compile(r"^[ACGTN]+-CR\d{3}-\d+-(exp_A|exp_B)$")
+        for idx in crispr.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"obs.index entry {idx!r} does not match expected format"
+            )
+        assert crispr.obs["experiment"].value_counts().to_dict() == {
+            "exp_A": 3,
+            "exp_B": 3,
+        }
+
+
+class TestCREdgeCases:
+    def test_cr_prefix_crispr_positive_conversion_with_experiment(self, tmp_path):
+        """Positive path: CR->BC conversion succeeds and the experiment suffix survives."""
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT"]
+        _build_cyto_dir(cyto_outdir, "exp_simple", "gex", 1, "BC001", seqs, 100, 26)
+        _build_cyto_dir(cyto_outdir, "exp_simple", "crispr", 1, "CR001", seqs, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "exp_simple",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+CR001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        crispr = ad.read_h5ad(agg_outdir / "sample01" / "sample01_crispr.h5ad")
+
+        gex_pattern = re.compile(r"^[ACGTN]+-BC001-1-exp_simple$")
+        crispr_pattern = re.compile(r"^[ACGTN]+-BC001-1-exp_simple$")
+        for idx in gex.obs.index:
+            assert gex_pattern.match(idx) is not None
+        for idx in crispr.obs.index:
+            assert crispr_pattern.match(idx) is not None
+        # Attribution proves the polars match_barcode join worked end-to-end.
+        assert (gex.obs["n_umis_gex"] == 26).all()
+        assert (gex.obs["n_umis_gex"] != 0).all()
+
+    def test_cr_prefix_crispr_does_not_corrupt_experiment_named_CRISPR(self, tmp_path):
+        """experiment="CRISPR_screen" must not be rewritten to "BCISPR_screen" by the CR->BC pass."""
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT"]
+        _build_cyto_dir(cyto_outdir, "CRISPR_screen", "gex", 1, "BC001", seqs, 100, 26)
+        _build_cyto_dir(cyto_outdir, "CRISPR_screen", "crispr", 1, "CR001", seqs, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "CRISPR_screen",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+CR001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        pattern = re.compile(r"^[ACGTN]+-BC001-1-CRISPR_screen$")
+        for idx in gex.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"obs.index entry {idx!r} -- experiment name corrupted by CR->BC pass"
+            )
+        assert (gex.obs["experiment"] == "CRISPR_screen").all()
+
+        # Polars-side correctness: match_barcode in the parquets retains the literal experiment name.
+        assignments = pl.read_parquet(
+            agg_outdir / "sample01" / "sample01_assignments.parquet"
+        )
+        for mb in assignments["match_barcode"].to_list():
+            assert mb.endswith("-CRISPR_screen"), (
+                f"assignments match_barcode {mb!r} corrupted"
+            )
+            assert "BCISPR" not in mb
+
+    def test_bc_prefix_crispr_skips_conversion(self, tmp_path):
+        """CRISPR using a BC-prefix barcode takes the standard (non-CR-conversion) branch.
+
+        Realistic configuration: GEX and CRISPR share the same flex barcode (`BC001`)
+        so the merge keys align across modes. Assignments `cell` column carries `BC001`
+        with no `CR` substring, so `_process_gex_crispr_set` takes the standard branch
+        and obs.index retains the BC prefix end-to-end.
+        """
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs = ["AAAACCCCGGGGTTTT", "ACGTACGTACGTACGT"]
+        _build_cyto_dir(cyto_outdir, "exp_bc", "gex", 1, "BC001", seqs, 100, 26)
+        _build_cyto_dir(cyto_outdir, "exp_bc", "crispr", 1, "BC001", seqs, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "exp_bc",
+                "sample": "sample01",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "BC001+BC001",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        process_sample("sample01", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample01" / "sample01_gex.h5ad")
+        crispr = ad.read_h5ad(agg_outdir / "sample01" / "sample01_crispr.h5ad")
+
+        pattern = re.compile(r"^[ACGTN]+-BC001-1-exp_bc$")
+        for idx in gex.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"unexpected gex obs.index entry {idx!r}"
+            )
+        for idx in crispr.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"unexpected crispr obs.index entry {idx!r}"
+            )
+        # Standard branch should have produced a real (non-NaN) join.
+        assert (gex.obs["assignment"] == "guide_1").all()
+        assert (gex.obs["n_umis_gex"] == 26).all()

--- a/tests/test_aggregate_reads_nan.py
+++ b/tests/test_aggregate_reads_nan.py
@@ -25,24 +25,28 @@ from pycyto.aggregate import _process_gex_crispr_set
 #
 # ``match_barcode`` construction inside ``_process_gex_crispr_set`` (Flex-V1,
 # non-CR path):
-#   assignments.match_barcode = cell    + "-" + lane_id
-#   reads_df.match_barcode    = cell_id + "-" + lane_id   (cell_id already
-#                                                          built by the loader
-#                                                          as barcode + "-" + bc_idx)
-# The GEX adata obs index is built by the loader as <barcode> + "-" + lane_id.
-# To make all three align we use a barcode that already embeds bc_idx so the
+#   assignments.match_barcode = cell    + "-" + lane_id + "-" + experiment
+#   reads_df.match_barcode    = cell_id + "-" + lane_id + "-" + experiment
+#                                                          (cell_id already
+#                                                           built by the loader
+#                                                           as barcode + "-" + bc_idx)
+# The GEX adata obs index is built by the loader as
+#   <barcode> + "-" + lane_id + "-" + experiment.
+# To make all four align we use a barcode that already embeds bc_idx so the
 # adata index equals reads.match_barcode.
 # ---------------------------------------------------------------------------
 
 LANE_ID = "1"
 BC_IDX = "TestGEX_BC1"
+EXPERIMENT = "E1"
 
-# adata index == <obs barcode> + "-" + lane_id, must equal reads match_barcode.
+# adata index == <obs barcode> + "-" + lane_id + "-" + experiment, must equal
+# reads match_barcode.
 BARCODE_BOTH = "AAAACCCC-TestGEX_BC1"
 BARCODE_GEX_ONLY = "GGGGTTTT-TestGEX_BC1"
 
-MATCH_BOTH = f"{BARCODE_BOTH}-{LANE_ID}"
-MATCH_GEX_ONLY = f"{BARCODE_GEX_ONLY}-{LANE_ID}"
+MATCH_BOTH = f"{BARCODE_BOTH}-{LANE_ID}-{EXPERIMENT}"
+MATCH_GEX_ONLY = f"{BARCODE_GEX_ONLY}-{LANE_ID}-{EXPERIMENT}"
 
 # Known "real" GEX read values we expect to survive onto every GEX cell.
 GEX_READS = {
@@ -63,12 +67,19 @@ def _make_gex_adata() -> ad.AnnData:
         X=np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
     )
     adata.obs_names = obs_index
-    # index += "-" + lane_id, mimicking _load_gex_anndata_for_experiment_sample
+    # index += "-" + lane_id + "-" + experiment, mimicking
+    # _load_gex_anndata_for_experiment_sample.
     adata.obs["sample"] = "S1"
-    adata.obs["experiment"] = "E1"
+    adata.obs["experiment"] = EXPERIMENT
     adata.obs["lane_id"] = LANE_ID
     adata.obs["bc_idx"] = BC_IDX
-    adata.obs.index = adata.obs.index + "-" + adata.obs["lane_id"].astype(str)
+    adata.obs.index = (
+        adata.obs.index
+        + "-"
+        + adata.obs["lane_id"].astype(str)
+        + "-"
+        + adata.obs["experiment"].astype(str)
+    )
     return adata
 
 
@@ -77,16 +88,23 @@ def _make_crispr_adata() -> ad.AnnData:
     adata = ad.AnnData(X=np.array([[5.0]], dtype=np.float32))
     adata.obs_names = [BARCODE_BOTH]
     adata.obs["sample"] = "S1"
-    adata.obs["experiment"] = "E1"
+    adata.obs["experiment"] = EXPERIMENT
     adata.obs["lane_id"] = LANE_ID
     adata.obs["bc_idx"] = BC_IDX
-    adata.obs.index = adata.obs.index + "-" + adata.obs["lane_id"].astype(str)
+    adata.obs.index = (
+        adata.obs.index
+        + "-"
+        + adata.obs["lane_id"].astype(str)
+        + "-"
+        + adata.obs["experiment"].astype(str)
+    )
     return adata
 
 
 def _make_assignments() -> pl.DataFrame:
     """Assignments table (CRISPR modality) -- only the 'both' cell."""
-    # `cell` + "-" + lane_id == match_barcode == BARCODE_BOTH + "-" + lane_id
+    # `cell` + "-" + lane_id + "-" + experiment == match_barcode
+    #                                           == BARCODE_BOTH + "-" + lane_id + "-" + experiment
     return pl.DataFrame(
         {
             "cell": [BARCODE_BOTH],
@@ -94,7 +112,7 @@ def _make_assignments() -> pl.DataFrame:
             "umis": [ASSIGN_BOTH["umis"]],
             "moi": [ASSIGN_BOTH["moi"]],
             "sample": ["S1"],
-            "experiment": ["E1"],
+            "experiment": [EXPERIMENT],
             "lane_id": [LANE_ID],
             "bc_idx": [BC_IDX],
         }
@@ -106,13 +124,14 @@ def _make_reads() -> pl.DataFrame:
 
     ``cell_id`` is the loader-built ``barcode + "-" + bc_idx`` -- but our
     barcodes already embed the bc_idx, so cell_id is just the barcode here;
-    ``match_barcode`` then becomes cell_id + "-" + lane_id, matching the adata
-    index and the assignments match_barcode.
+    ``match_barcode`` then becomes cell_id + "-" + lane_id + "-" + experiment,
+    matching the adata index and the assignments match_barcode.
     """
     rows = []
     # gex reads: one per GEX cell (the bug source for the gex-only cell).
     for match, vals in GEX_READS.items():
-        cell_id = match.rsplit("-", 1)[0]  # strip lane suffix back to cell_id
+        # strip the trailing "-lane-experiment" back to cell_id.
+        cell_id = match.rsplit("-", 2)[0]
         rows.append(
             {
                 "barcode": cell_id,
@@ -121,13 +140,13 @@ def _make_reads() -> pl.DataFrame:
                 "n_umis": vals["n_umis"],
                 "bc_idx": BC_IDX,
                 "lane_id": LANE_ID,
-                "experiment": "E1",
+                "experiment": EXPERIMENT,
                 "sample": "S1",
                 "mode": "gex",
             }
         )
     for match, vals in CRISPR_READS.items():
-        cell_id = match.rsplit("-", 1)[0]
+        cell_id = match.rsplit("-", 2)[0]
         rows.append(
             {
                 "barcode": cell_id,
@@ -136,7 +155,7 @@ def _make_reads() -> pl.DataFrame:
                 "n_umis": vals["n_umis"],
                 "bc_idx": BC_IDX,
                 "lane_id": LANE_ID,
-                "experiment": "E1",
+                "experiment": EXPERIMENT,
                 "sample": "S1",
                 "mode": "crispr",
             }


### PR DESCRIPTION
## Summary

- Fixes #46. When the same `sample` appeared under two different `experiment` values in `pycyto aggregate` (`gex+crispr` mode), the per-sample worker crashed with `ValueError: shape is inconsistent with obs` because the `match_barcode` join key and the parallel `obs.index` rewrite did not include `experiment`. Same-sequence cells in different experiments collided during the merge, producing a many-to-many join.
- Appends `experiment` to `obs.index` in both loaders and to all four `match_barcode` expressions in `_process_gex_crispr_set`. Tightens the pandas `CR`→`BC` replacement from an all-occurrences `str.replace("CR", "BC")` to an anchored regex `r"^([ACGTN]+)-CR(\d+)-"` so experiment names containing `CR` (e.g. `CRISPR_screen`) are not corrupted. Polars equivalents pass explicit `n=1`.
- The fix is applied universally in the loaders, so single-modal `gex`-only and `crispr`-only outputs also receive the disambiguated `obs.index` — this prevents a latent silent rename via `obs_names_make_unique()` in those branches.

### Behavior change (output format)

The four-part suffix becomes part of the public output:

- `obs.index` in `{sample}_gex.h5ad` / `{sample}_crispr.h5ad`: `{cell_seq}-{flex_bc}-{lane}` → `{cell_seq}-{flex_bc}-{lane}-{experiment}`
- `match_barcode` in `{sample}_assignments.parquet` / `{sample}_reads.parquet`: same change (CR→BC applied where applicable).

External consumers depending on the old three-part format need a one-line update.

## Test plan

- [x] `uv run pytest tests/` — 89 passed (80 existing + 9 new in `tests/test_aggregate.py`)
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — 5 diagnostics, identical to the pre-fix baseline on `main` (no regression)
- [x] New tests cover: multi-experiment same-sample crash absence, cell count, per-experiment attribution, single-experiment regression, GEX-only multi-experiment, CRISPR-only multi-experiment, positive CR→BC conversion, `experiment="CRISPR_screen"` corruption safety, BC-prefix CRISPR pathway.

## Flagged for follow-up (out of scope)

Pre-existing Flex-V2 detection bug at `aggregate.py:149`: `obs.index[0].split("-")[1]` returns `"A"` for `A-A01`-format barcodes and never matches `_is_flex_v2_barcode`. Detection has always silently fallen through to the Flex-V1 branch for Flex-V2 inputs. This PR neither introduces nor worsens the bug, but a dedicated follow-up should fix it and add Flex-V2 multi-experiment test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)