### PR TITLE
fix(aggregate): detect Flex-V2 format via bc_idx obs column (#49)

### DIFF
--- a/src/pycyto/aggregate.py
+++ b/src/pycyto/aggregate.py
@@ -9,6 +9,8 @@ import anndata.experimental as ade
 import pandas as pd
 import polars as pl
 
+from .config import _is_flex_v2_barcode
+
 # Set up logger for aggregation
 logger = logging.getLogger("pycyto.aggregate")
 
@@ -27,9 +29,22 @@ _ASSIGNMENT_PER_GUIDE_COLS = (
 )
 
 
-def _is_flex_v2_barcode(barcode: str) -> bool:
-    """Check if barcode follows Flex-V2 format: A-A01, B-C05, D-H12, etc."""
-    return re.match(r"^[ABCD]-[ABCDEFGH](0[1-9]|1[0-2])$", barcode) is not None
+def _get_gex_sample_barcode(gex_adata: ad.AnnData) -> str:
+    """Return a representative source flex barcode for the GEX cells.
+
+    Reads the per-cell ``bc_idx`` obs column (populated by the GEX loader with
+    the raw flex barcode, e.g. ``BC001`` or ``A-A01``). This is robust to the
+    Flex-V2 barcode form ``A-A01``, which itself contains the ``-`` separator
+    used between obs.index fields -- re-parsing the index by position would
+    split ``A-A01`` and misidentify the format (issue #49).
+
+    Returns ``""`` when ``gex_adata`` has no cells (e.g. all constituent
+    per-barcode AnnData objects loaded zero cells); ``_is_flex_v2_barcode("")``
+    is ``False``, a safe no-op since there are then no cells to convert.
+    """
+    if len(gex_adata.obs) == 0:
+        return ""
+    return str(gex_adata.obs["bc_idx"].iloc[0])
 
 
 def lazy_load_adata(path: str) -> ad.AnnData:
@@ -159,11 +174,7 @@ def _process_gex_crispr_set(
 
     # Check if we need to convert CR→BC for Flex-V1
     # Flex-V2 uses a single naming scheme, so no conversion needed
-    sample_barcode = (
-        str(gex_adata.obs.index[0]).split("-")[1]
-        if len(gex_adata.obs.index) > 0
-        else ""
-    )
+    sample_barcode = _get_gex_sample_barcode(gex_adata)
     is_flex_v2 = _is_flex_v2_barcode(sample_barcode)
 
     if not is_flex_v2 and assignments["cell"].str.contains("CR").any():

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -18,12 +18,18 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import polars as pl
+import pytest
 import scipy.sparse as sp
 
 # Add src to path for imports (mirror the pattern used by other tests).
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from pycyto.aggregate import process_sample
+from pycyto.aggregate import (
+    _get_gex_sample_barcode,
+    process_sample,
+)
+from pycyto.aggregate import _is_flex_v2_barcode as agg_is_flex_v2_barcode
+from pycyto.config import _is_flex_v2_barcode as cfg_is_flex_v2_barcode
 from pycyto.config import parse_config
 
 
@@ -567,3 +573,189 @@ class TestCREdgeCases:
         # Standard branch should have produced a real (non-NaN) join.
         assert (gex.obs["assignment"] == "guide_1").all()
         assert (gex.obs["n_umis_gex"] == 26).all()
+
+
+# ---------------------------------------------------------------------------
+# Issue #49: Flex-V2 format detection in `_process_gex_crispr_set`.
+# ---------------------------------------------------------------------------
+
+
+def _make_gex_adata_with_bc_idx(index_str: str, bc_idx: str) -> ad.AnnData:
+    """Build a 1-cell GEX AnnData with the obs fields `_get_gex_sample_barcode` reads.
+
+    Sets BOTH `obs.index` (the full `{seq}-{flex_bc}-{lane}-{experiment}` form,
+    so the pre-fix positional `split("-")[1]` can be reproduced) AND the
+    `bc_idx` obs column (the raw flex barcode, which the loader stores and the
+    helper reads). Other loader-set columns (`sample`, `experiment`, `lane_id`)
+    are intentionally omitted -- the helper does not read them.
+    """
+    return ad.AnnData(
+        X=sp.csr_matrix(np.zeros((1, 1), dtype=np.float32)),
+        obs=pd.DataFrame({"bc_idx": [bc_idx]}, index=pd.Index([index_str])),
+        var=pd.DataFrame(index=pd.Index(["gene_1"])),
+    )
+
+
+class TestGetGexSampleBarcode:
+    """Unit coverage for the `_get_gex_sample_barcode` detection helper (issue #49)."""
+
+    @pytest.mark.parametrize(
+        "index_str,bc_idx,expected",
+        [
+            # Flex-V1: obs.index has 4 '-'-delimited tokens.
+            ("AAAACCCCGGGGTTTT-BC001-1-exp1", "BC001", "BC001"),
+            # Flex-V2 hyphen: flex barcode A-A01 embeds a '-', so the index has 5 tokens.
+            ("AAAACCCCGGGGTTTT-A-A01-1-exp1", "A-A01", "A-A01"),
+            # Flex-V2 underscore: A_A01 form.
+            ("AAAACCCCGGGGTTTT-A_A01-1-exp1", "A_A01", "A_A01"),
+        ],
+    )
+    def test_reads_raw_barcode_from_bc_idx(self, index_str, bc_idx, expected):
+        adata = _make_gex_adata_with_bc_idx(index_str, bc_idx)
+        assert _get_gex_sample_barcode(adata) == expected
+
+    def test_empty_obs_returns_empty_string(self):
+        empty = ad.AnnData(
+            X=sp.csr_matrix(np.zeros((0, 1), dtype=np.float32)),
+            obs=pd.DataFrame(
+                {"bc_idx": pd.Series([], dtype="object")},
+                index=pd.Index([], dtype="str"),
+            ),
+            var=pd.DataFrame(index=pd.Index(["gene_1"])),
+        )
+        assert _get_gex_sample_barcode(empty) == ""
+        assert agg_is_flex_v2_barcode("") is False
+
+    def test_red_green_fixes_flex_v2_misdetection(self):
+        """The pre-fix positional split misclassifies V2; the helper classifies it correctly.
+
+        Genuine regression guard: if `_get_gex_sample_barcode` is ever reverted
+        to `obs.index[0].split("-")[1]`, `new_barcode` becomes "A" and the
+        `agg_is_flex_v2_barcode(new_barcode)` assertion fails.
+        """
+        adata = _make_gex_adata_with_bc_idx("AAAACCCCGGGGTTTT-A-A01-1-exp1", "A-A01")
+        # Reproduce the pre-fix expression inline: the positional split yields "A".
+        old_barcode = adata.obs.index[0].split("-")[1]
+        # The helper reads bc_idx, yielding the full "A-A01".
+        new_barcode = _get_gex_sample_barcode(adata)
+        # Documents the bug premise: the old token is classified as not-V2.
+        assert not agg_is_flex_v2_barcode(old_barcode)
+        # Real regression guard: fails if the helper reverts to the positional split.
+        assert agg_is_flex_v2_barcode(new_barcode)
+        # The fix changes the detected token (old "A" != new "A-A01").
+        assert old_barcode != new_barcode
+
+    def test_dedup_uses_config_authoritative_function(self):
+        """aggregate's `_is_flex_v2_barcode` IS config's (dedup via import), so the
+        underscore form A_A01 -- rejected by the old hyphen-only duplicate -- now matches."""
+        assert agg_is_flex_v2_barcode is cfg_is_flex_v2_barcode
+        assert agg_is_flex_v2_barcode("A_A01") is True
+        assert agg_is_flex_v2_barcode("A-A01") is True
+        assert agg_is_flex_v2_barcode("BC001") is False
+
+
+class TestFlexV2MultiExperiment:
+    """End-to-end Flex-V2 gex+crispr aggregation across two experiments (issue #49).
+
+    Flex-V2 uses a single naming scheme: the SAME barcode identifier (`A-A01`)
+    is used for both GEX and CRISPR, so there is no `+` pairing and no CR->BC
+    conversion. This guards that V2 barcodes survive aggregation unmodified.
+    """
+
+    def _make_v2_fixture(self, tmp_path, n_umis_a=26, n_umis_b=3):
+        cyto_outdir = tmp_path / "cyto_outdir"
+        cyto_outdir.mkdir()
+        agg_outdir = tmp_path / "agg_outdir"
+        agg_outdir.mkdir()
+
+        seqs_a = _OVERLAP_SEQS + _EXP_A_ONLY
+        seqs_b = _OVERLAP_SEQS + _EXP_B_ONLY
+
+        # Same V2 barcode for both modes (no BC/CR split in Flex-V2).
+        _build_cyto_dir(cyto_outdir, "exp_A", "gex", 1, "A-A01", seqs_a, 100, n_umis_a)
+        _build_cyto_dir(cyto_outdir, "exp_A", "crispr", 1, "A-A01", seqs_a, 50, 7)
+        _build_cyto_dir(cyto_outdir, "exp_B", "gex", 1, "A-A01", seqs_b, 100, n_umis_b)
+        _build_cyto_dir(cyto_outdir, "exp_B", "crispr", 1, "A-A01", seqs_b, 50, 7)
+
+        libraries = {
+            "GEX": str(tmp_path / "gex_probes.tsv"),
+            "GUIDES": str(tmp_path / "guides.tsv"),
+        }
+        samples = [
+            {
+                "experiment": "exp_A",
+                "sample": "sample_v2",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "A-A01",
+            },
+            {
+                "experiment": "exp_B",
+                "sample": "sample_v2",
+                "mode": "gex+crispr",
+                "features": "GEX+GUIDES",
+                "barcodes": "A-A01",
+            },
+        ]
+        config = _write_and_parse_config(tmp_path, libraries, samples)
+        return cyto_outdir, agg_outdir, config
+
+    def test_v2_outputs_exist_with_correct_cell_counts(self, tmp_path):
+        cyto_outdir, agg_outdir, config = self._make_v2_fixture(tmp_path)
+        process_sample("sample_v2", config, str(cyto_outdir), str(agg_outdir))
+
+        sample_dir = agg_outdir / "sample_v2"
+        assert (sample_dir / "sample_v2_gex.h5ad").exists()
+        assert (sample_dir / "sample_v2_crispr.h5ad").exists()
+        assert (sample_dir / "sample_v2_assignments.parquet").exists()
+        assert (sample_dir / "sample_v2_reads.parquet").exists()
+
+        gex = ad.read_h5ad(sample_dir / "sample_v2_gex.h5ad")
+        assert gex.shape[0] == 10
+        assert gex.obs["experiment"].value_counts().to_dict() == {
+            "exp_A": 5,
+            "exp_B": 5,
+        }
+        assert gex.obs.index.is_unique
+
+        # V2 barcode A-A01 preserved end-to-end; NO CR->BC rewrite. The index has
+        # 5 '-'-delimited tokens (the flex barcode A-A01 embeds a '-').
+        pattern = re.compile(r"^[ACGTN]+-A-A01-\d+-(exp_A|exp_B)$")
+        for idx in gex.obs.index:
+            assert pattern.match(idx) is not None, (
+                f"obs.index entry {idx!r} does not match expected V2 format"
+            )
+
+    def test_v2_attribution_per_experiment(self, tmp_path):
+        cyto_outdir, agg_outdir, config = self._make_v2_fixture(
+            tmp_path, n_umis_a=26, n_umis_b=3
+        )
+        process_sample("sample_v2", config, str(cyto_outdir), str(agg_outdir))
+
+        gex = ad.read_h5ad(agg_outdir / "sample_v2" / "sample_v2_gex.h5ad")
+        exp_a_rows = gex.obs[gex.obs["experiment"] == "exp_A"]
+        exp_b_rows = gex.obs[gex.obs["experiment"] == "exp_B"]
+
+        assert (exp_a_rows["n_umis_gex"] == 26).all()
+        assert (exp_b_rows["n_umis_gex"] == 3).all()
+        assert (exp_a_rows["n_reads_gex"] == 100).all()
+        assert (exp_b_rows["n_reads_gex"] == 100).all()
+        assert (exp_a_rows["assignment"] == "guide_1").all()
+        assert (exp_b_rows["assignment"] == "guide_1").all()
+
+        # match_barcode in both parquets must retain the V2 barcode A-A01 intact
+        # (the standard/no-conversion branch must NOT apply a CR->BC rewrite for
+        # Flex-V2). Mirrors the V1 attribution parquet assertions.
+        assignments = pl.read_parquet(
+            agg_outdir / "sample_v2" / "sample_v2_assignments.parquet"
+        )
+        reads = pl.read_parquet(agg_outdir / "sample_v2" / "sample_v2_reads.parquet")
+        mb_pattern = re.compile(r"^[ACGTN]+-A-A01-\d+-(exp_A|exp_B)$")
+        for mb in assignments["match_barcode"].to_list():
+            assert mb_pattern.match(mb) is not None, (
+                f"assignments match_barcode {mb!r} unexpected"
+            )
+        for mb in reads["match_barcode"].to_list():
+            assert mb_pattern.match(mb) is not None, (
+                f"reads match_barcode {mb!r} unexpected"
+            )


### PR DESCRIPTION
## Summary

Fixes #49. `_process_gex_crispr_set` detected the Flex-V2 barcode format by positionally splitting the first GEX cell's `obs.index`:

```python
sample_barcode = str(gex_adata.obs.index[0]).split("-")[1]
```

The post-#46 obs.index format is `{cell_seq}-{flex_bc}-{lane}-{experiment}`. For Flex-V2 the flex barcode `A-A01` itself contains a `-`, so the V2 index `AAAA-A-A01-1-exp1` splits into **5** `-`-delimited tokens and position `[1]` is just the set prefix `"A"` — which never matches the Flex-V2 regex. `is_flex_v2` was therefore **always `False`** for Flex-V2 input.

This is latent today (the only consumer of `is_flex_v2` is the CR→BC conversion gate, and V2 barcodes never contain `CR`, so the buggy and correct values took the same no-conversion branch — only the debug log differed). But the detection was wrong, and any future V2-specific logic gated on it would silently never run.

## Changes

**`src/pycyto/aggregate.py`**
- Add `_get_gex_sample_barcode(gex_adata)` helper that reads the per-cell `bc_idx` obs column (the raw flex barcode the loaders store, e.g. `BC001` / `A-A01`), robust to the V2 `-`-in-barcode form. Returns `""` on empty obs.
- Swap the inline positional-split detection to use the helper.
- Dedup `_is_flex_v2_barcode`: import the authoritative, underscore-aware version from `config.py` and delete `aggregate.py`'s stale hyphen-only copy. This also fixes detection of the underscore form `A_A01`.

**`tests/test_aggregate.py`** (+8 tests)
- Parametrized helper unit test: V1 (`BC001`), V2 hyphen (`A-A01`), V2 underscore (`A_A01`), empty obs.
- A genuine red-green regression guard (inlines the pre-fix expression and asserts it disagrees with the helper; fails if the helper ever reverts to the positional split).
- A dedup identity lock (`aggregate._is_flex_v2_barcode is config._is_flex_v2_barcode`).
- End-to-end Flex-V2 multi-experiment `gex+crispr` fixture: asserts the four output files, per-experiment cell counts, `obs.index` format (`-A-A01-` preserved, no CR→BC rewrite), uniqueness, and read/UMI + parquet `match_barcode` attribution.

## Testing

- `uv run pytest tests/` → **103 passed** (95 existing + 8 new), 0 warnings.
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` → all clean.
- Red-green proven by a revert-run-restore check: injecting the old `split("-")[1]` makes the V2 unit cases fail; restoring returns to green.

No public API or output-file schema changes; Flex-V1 behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
