### PR TITLE
chore(semver): bump to 0.1.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pycyto"
-version = "0.1.14"
+version = "0.1.15"
 description = "Python utilities used by cyto"
 license = "BSD-3-Clause"
 readme = "README.md"


### PR DESCRIPTION
Bump version `0.1.14` → `0.1.15` for PyPI release.

### Changes since 0.1.14
- fix(aggregate): detect Flex-V2 format via bc_idx obs column (#49, #50)
- fix: include experiment in match_barcode and obs.index (#46, #47)
- fix: use ty-compatible type-ignore suppressions in CI (#48)
- fix(aggregate): populate reads/UMI for GEX-only cells in gex+crispr mode (#45)

### Notes
- Only `pyproject.toml` changes; `uv.lock` is gitignored, nothing else to sync.
- A **draft** release `pycyto-0.1.15` has been created. It does **not** trigger the PyPI publish workflow until published. Publish it after this PR merges to ship to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
